### PR TITLE
expose DB size and modification time via /stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: go
 go:
   - 1.3.3
-  - 1.4.1
+  - 1.4.2
 script:
-  - curl -s https://raw.githubusercontent.com/pote/gpm/v1.3.1/bin/gpm > gpm
+  - curl -s https://raw.githubusercontent.com/pote/gpm/v1.3.2/bin/gpm > gpm
   - chmod +x gpm
   - ./gpm install
   - ./test.sh
 notifications:
   email: false
+sudo: false
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Records are matched by the first data column.
   "get_misses": 0,
   "get_average_request": 448,
   "get_95": 1323,
-  "get_99": 1323
+  "get_99": 1323,
+  "db_size": 767557632,
+  "db_mtime": 1435463934
 }
 ```
  

--- a/dist.sh
+++ b/dist.sh
@@ -22,7 +22,7 @@ for os in linux darwin; do
     echo "... building v$version for $os/$arch"
     BUILD=$(mktemp -d -t sortdb)
     TARGET="sortdb-$version.$os-$arch.$goversion"
-    GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/google_auth_proxy || exit 1
+    GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/sortdb || exit 1
     pushd $BUILD
     tar czvf $TARGET.tar.gz $TARGET
     mv $TARGET.tar.gz $DIR/dist

--- a/http.go
+++ b/http.go
@@ -165,11 +165,14 @@ type statsResponse struct {
 	MgetAvg      time.Duration `json:"mget_average_request"` // Microsecond
 	Mget95       time.Duration `json:"mget_95"`              // Microsecond
 	Mget99       time.Duration `json:"mget_99"`              // Microsecond
+	DBSize       int64         `json:"db_size"`
+	DBMtime      int64         `json:"db_mtime"`
 }
 
 func (s *httpServer) statsHandler(w http.ResponseWriter, req *http.Request) {
 	getStats := s.GetMetrics.Stats()
 	mgetStats := s.MgetMetrics.Stats()
+	size, mtime := s.ctx.db.Info()
 	stats := statsResponse{
 		Requests:     atomic.LoadUint64(&s.Requests),
 		SeekCount:    s.ctx.db.SeekCount(),
@@ -185,6 +188,8 @@ func (s *httpServer) statsHandler(w http.ResponseWriter, req *http.Request) {
 		MgetAvg:      mgetStats.Avg / time.Microsecond,
 		Mget95:       mgetStats.P95 / time.Microsecond,
 		Mget99:       mgetStats.P99 / time.Microsecond,
+		DBSize:       int64(size),
+		DBMtime:      mtime.Unix(),
 	}
 	// evbuffer_add_printf(evb, "\"total_seeks\": %"PRIu64",", total_seeks);
 

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/riobard/go-mmap"
 )
@@ -28,6 +29,17 @@ func New(f *os.File) (*DB, error) {
 	db := &DB{RecordSeparator: '\t', LineEnding: '\n', size: -1}
 	err := db.Open(f)
 	return db, err
+}
+
+// Info returns the mmaped backing file size and modification time
+func (db *DB) Info() (int, time.Time) {
+	db.RLock()
+	defer db.RUnlock()
+	if db.f == nil {
+		return 0, time.Time{}
+	}
+	fi, _ := db.f.Stat()
+	return db.size, fi.ModTime()
 }
 
 // Open the DB against a backing file

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.1-alpha"
+const VERSION = "1.0"


### PR DESCRIPTION
This exposes db metadata via the existing `/stats` endpoint
