### PR TITLE
Adding forward match and range matching to sortdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Records are matched by the first data column.
  * `/mget?key=...&key=...` Response is `text/plain` with all records that match
    (including the key), or an empty 200 if no matches
 
- * `/fwmatch?key=...` Response is `text/plain` with the full records that have
-   keys lexically greater than or equal to the key, or a 404 if no such records
-   exist.
+ * `/fwmatch?key=...` Also known as prefix match. Response is `text/plain` with
+   the full records that have keys that start with the given key as a prefix,
+   or a 404 if no such records exist.
 
  * `/range?start=...&end=...` Response is `text/plain` with the full records
    that have keys lexically greater than or equal to the start key and less

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Records are matched by the first data column.
   "total_requests": 3,
 }
 {
-  "total_requests":2
-  "total_seeks":24
+  "total_requests": 2,
+  "total_seeks": 24,
   "get_requests": 3,
   "get_hits": 3,
   "get_misses": 0,
@@ -55,18 +55,18 @@ Records are matched by the first data column.
   "mget_average_request": 0,
   "mget_95": 0,
   "mget_99": 0,
-  "fwmatch_requests":1
-  "fwmatch_hits":1
-  "fwmatch_misses":0
-  "fwmatch_average_request":10
-  "fwmatch_95":10
-  "fwmatch_99":10
-  "range_requests":2
-  "range_hits":1
-  "range_misses":1
-  "range_average_request":18
-  "range_95":24
-  "range_99":24
+  "fwmatch_requests": 1,
+  "fwmatch_hits": 1,
+  "fwmatch_misses": 0,
+  "fwmatch_average_request": 10,
+  "fwmatch_95": 10,
+  "fwmatch_99": 10,
+  "range_requests": 2,
+  "range_hits": 1,
+  "range_misses": 1,
+  "range_average_request": 18,
+  "range_95": 24,
+  "range_99": 24,
   "db_size": 767557632,
   "db_mtime": 1435463934
 }

--- a/README.md
+++ b/README.md
@@ -19,27 +19,54 @@ Records are matched by the first data column.
 
  * `/ping`  responsds with 200 `OK`
 
- * `/get?key=...` Response is `text/plain` with the full record that matched (excluding the key), or a 404 if no match.
+ * `/get?key=...` Response is `text/plain` with the full record that matched
+   (excluding the key), or a 404 if no match.
     
- * `/mget?key=...&key=...` Response is `text/plain` with all records that match (including the key), or an empty 200 if no matches
+ * `/mget?key=...&key=...` Response is `text/plain` with all records that match
+   (including the key), or an empty 200 if no matches
+
+ * `/fwmatch?key=...` Response is `text/plain` with the full records that have
+   keys lexically greater than or equal to the key, or a 404 if no such records
+   exist.
+
+ * `/range?start=...&end=...` Response is `text/plain` with the full records
+   that have keys lexically greater than or equal to the start key and less
+   than or equal to the end key, or a 404 if no such records exist. The end key
+   must be lexically greater than or equal to the start key.
 
  * `/stats` Response is `application/json` with the following payload
 
 ```json
 {
   "total_requests": 3,
-  "mget_requests": 0,
-  "mget_hits": 0,
-  "mget_misses": 0,
-  "mget_average_request": 0,
-  "mget_95": 0,
-  "mget_99": 0,
+}
+{
+  "total_requests":2
+  "total_seeks":24
   "get_requests": 3,
   "get_hits": 3,
   "get_misses": 0,
   "get_average_request": 448,
   "get_95": 1323,
   "get_99": 1323,
+  "mget_requests": 0,
+  "mget_hits": 0,
+  "mget_misses": 0,
+  "mget_average_request": 0,
+  "mget_95": 0,
+  "mget_99": 0,
+  "fwmatch_requests":1
+  "fwmatch_hits":1
+  "fwmatch_misses":0
+  "fwmatch_average_request":10
+  "fwmatch_95":10
+  "fwmatch_99":10
+  "range_requests":2
+  "range_hits":1
+  "range_misses":1
+  "range_average_request":18
+  "range_95":24
+  "range_99":24
   "db_size": 767557632,
   "db_mtime": 1435463934
 }

--- a/http.go
+++ b/http.go
@@ -179,7 +179,7 @@ func (s *httpServer) fwmatchHandler(w http.ResponseWriter, req *http.Request) {
 	} else {
 		atomic.AddUint64(&s.FwMatchHits, 1)
 		w.Header().Set("Content-Type", "text/plain")
-		w.Header().Set("Content-Length", strconv.Itoa(len(content)+1))
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
 		w.Write(content)
 	}
 	s.FwMatchMetrics.Status(startTime)
@@ -214,7 +214,7 @@ func (s *httpServer) rangeHandler(w http.ResponseWriter, req *http.Request) {
 	} else {
 		atomic.AddUint64(&s.RangeHits, 1)
 		w.Header().Set("Content-Type", "text/plain")
-		w.Header().Set("Content-Length", strconv.Itoa(len(content)+1))
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)))
 		w.Write(content)
 	}
 	s.RangeMetrics.Status(startTime)

--- a/http.go
+++ b/http.go
@@ -196,12 +196,10 @@ func (s *httpServer) rangeHandler(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "MISSING_ARG_END", 400)
 		return
 	}
-
 	if endKey < startKey {
 		http.Error(w, "MALFORMED_RANGE", 400)
 		return
 	}
-
 	startTime := time.Now()
 	atomic.AddUint64(&s.Requests, 1)
 	atomic.AddUint64(&s.RangeRequests, 1)

--- a/http.go
+++ b/http.go
@@ -112,15 +112,15 @@ func (s *httpServer) getHandler(w http.ResponseWriter, req *http.Request) {
 	atomic.AddUint64(&s.Requests, 1)
 	atomic.AddUint64(&s.GetRequests, 1)
 
-	needle := append([]byte(key), s.ctx.db.RecordSeparator)
+	needle := []byte(key)
 	line := s.ctx.db.Search(needle)
 
 	if len(line) == 0 {
 		atomic.AddUint64(&s.GetMisses, 1)
 		http.Error(w, "NOT_FOUND", 404)
 	} else {
-		// we only output the 'value'
-		line = line[len(needle):]
+		// we only output the 'value', so skip the needle and record separator
+		line = line[len(needle)+1:]
 		atomic.AddUint64(&s.GetHits, 1)
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Content-Length", strconv.Itoa(len(line)+1))
@@ -143,7 +143,7 @@ func (s *httpServer) mgetHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	var numFound int
 	for _, key := range req.Form["key"] {
-		needle := append([]byte(key), s.ctx.db.RecordSeparator)
+		needle := []byte(key)
 		line := s.ctx.db.Search(needle)
 		if len(line) != 0 {
 			numFound += 1

--- a/http.go
+++ b/http.go
@@ -17,23 +17,37 @@ import (
 type httpServer struct {
 	ctx *Context
 
-	Requests     uint64
-	GetRequests  uint64
-	GetHits      uint64
-	GetMisses    uint64
+	Requests uint64
+
+	GetRequests uint64
+	GetHits     uint64
+	GetMisses   uint64
+
 	MgetRequests uint64
 	MgetHits     uint64
 	MgetMisses   uint64
 
-	GetMetrics  *timer_metrics.TimerMetrics
-	MgetMetrics *timer_metrics.TimerMetrics
+	FwMatchRequests uint64
+	FwMatchHits     uint64
+	FwMatchMisses   uint64
+
+	RangeRequests uint64
+	RangeHits     uint64
+	RangeMisses   uint64
+
+	GetMetrics     *timer_metrics.TimerMetrics
+	MgetMetrics    *timer_metrics.TimerMetrics
+	FwMatchMetrics *timer_metrics.TimerMetrics
+	RangeMetrics   *timer_metrics.TimerMetrics
 }
 
 func NewHTTPServer(ctx *Context, logging bool) http.Handler {
 	h := &httpServer{
-		ctx:         ctx,
-		GetMetrics:  timer_metrics.NewTimerMetrics(1500, "/get"),
-		MgetMetrics: timer_metrics.NewTimerMetrics(1500, "/mget"),
+		ctx:            ctx,
+		GetMetrics:     timer_metrics.NewTimerMetrics(1500, "/get"),
+		MgetMetrics:    timer_metrics.NewTimerMetrics(1500, "/mget"),
+		FwMatchMetrics: timer_metrics.NewTimerMetrics(1500, "/fwmatch"),
+		RangeMetrics:   timer_metrics.NewTimerMetrics(1500, "/range"),
 	}
 	if logging {
 		return LoggingHandler(os.Stdout, h)
@@ -49,8 +63,10 @@ func (s *httpServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		s.getHandler(w, req)
 	case "/mget":
 		s.mgetHandler(w, req)
-	// case "/fwmatch":
-	// 	s.fwmatchHandler(w, req)
+	case "/fwmatch":
+		s.fwmatchHandler(w, req)
+	case "/range":
+		s.rangeHandler(w, req)
 	case "/stats":
 		s.statsHandler(w, req)
 	case "/reload":
@@ -144,6 +160,68 @@ func (s *httpServer) mgetHandler(w http.ResponseWriter, req *http.Request) {
 	s.MgetMetrics.Status(startTime)
 }
 
+func (s *httpServer) fwmatchHandler(w http.ResponseWriter, req *http.Request) {
+	key := req.FormValue("key")
+	if key == "" {
+		http.Error(w, "MISSING_ARG_KEY", 400)
+		return
+	}
+	startTime := time.Now()
+	atomic.AddUint64(&s.Requests, 1)
+	atomic.AddUint64(&s.FwMatchRequests, 1)
+
+	needle := []byte(key)
+	content := s.ctx.db.RangeMatch(needle, nil)
+
+	if len(content) == 0 {
+		atomic.AddUint64(&s.FwMatchMisses, 1)
+		http.Error(w, "NOT_FOUND", 404)
+	} else {
+		atomic.AddUint64(&s.FwMatchHits, 1)
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)+1))
+		w.Write(content)
+	}
+	s.FwMatchMetrics.Status(startTime)
+}
+
+func (s *httpServer) rangeHandler(w http.ResponseWriter, req *http.Request) {
+	startKey := req.FormValue("start")
+	if startKey == "" {
+		http.Error(w, "MISSING_ARG_START", 400)
+		return
+	}
+	endKey := req.FormValue("end")
+	if endKey == "" {
+		http.Error(w, "MISSING_ARG_END", 400)
+		return
+	}
+
+	if endKey < startKey {
+		http.Error(w, "MALFORMED_RANGE", 400)
+		return
+	}
+
+	startTime := time.Now()
+	atomic.AddUint64(&s.Requests, 1)
+	atomic.AddUint64(&s.RangeRequests, 1)
+
+	startNeedle := []byte(startKey)
+	endNeedle := []byte(endKey)
+	content := s.ctx.db.RangeMatch(startNeedle, endNeedle)
+
+	if len(content) == 0 {
+		atomic.AddUint64(&s.RangeMisses, 1)
+		http.Error(w, "NOT_FOUND", 404)
+	} else {
+		atomic.AddUint64(&s.RangeHits, 1)
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Length", strconv.Itoa(len(content)+1))
+		w.Write(content)
+	}
+	s.RangeMetrics.Status(startTime)
+}
+
 func (s *httpServer) reloadHandler(w http.ResponseWriter, req *http.Request) {
 	s.ctx.reloadChan <- 1
 	w.Header().Set("Content-Length", "2")
@@ -151,45 +229,71 @@ func (s *httpServer) reloadHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 type statsResponse struct {
-	Requests     uint64        `json:"total_requests"`
-	SeekCount    uint64        `json:"total_seeks"`
-	GetRequests  uint64        `json:"get_requests"`
-	GetHits      uint64        `json:"get_hits"`
-	GetMisses    uint64        `json:"get_misses"`
-	GetAvg       time.Duration `json:"get_average_request"` // Microsecond
-	Get95        time.Duration `json:"get_95"`              // Microsecond
-	Get99        time.Duration `json:"get_99"`              // Microsecond
-	MgetRequests uint64        `json:"mget_requests"`
-	MgetHits     uint64        `json:"mget_hits"`
-	MgetMisses   uint64        `json:"mget_misses"`
-	MgetAvg      time.Duration `json:"mget_average_request"` // Microsecond
-	Mget95       time.Duration `json:"mget_95"`              // Microsecond
-	Mget99       time.Duration `json:"mget_99"`              // Microsecond
-	DBSize       int64         `json:"db_size"`
-	DBMtime      int64         `json:"db_mtime"`
+	Requests        uint64        `json:"total_requests"`
+	SeekCount       uint64        `json:"total_seeks"`
+	GetRequests     uint64        `json:"get_requests"`
+	GetHits         uint64        `json:"get_hits"`
+	GetMisses       uint64        `json:"get_misses"`
+	GetAvg          time.Duration `json:"get_average_request"` // Microsecond
+	Get95           time.Duration `json:"get_95"`              // Microsecond
+	Get99           time.Duration `json:"get_99"`              // Microsecond
+	MgetRequests    uint64        `json:"mget_requests"`
+	MgetHits        uint64        `json:"mget_hits"`
+	MgetMisses      uint64        `json:"mget_misses"`
+	MgetAvg         time.Duration `json:"mget_average_request"` // Microsecond
+	Mget95          time.Duration `json:"mget_95"`              // Microsecond
+	Mget99          time.Duration `json:"mget_99"`              // Microsecond
+	FwMatchRequests uint64        `json:"fwmatch_requests"`
+	FwMatchHits     uint64        `json:"fwmatch_hits"`
+	FwMatchMisses   uint64        `json:"fwmatch_misses"`
+	FwMatchAvg      time.Duration `json:"fwmatch_average_request"` // Microsecond
+	FwMatch95       time.Duration `json:"fwmatch_95"`              // Microsecond
+	FwMatch99       time.Duration `json:"fwmatch_99"`              // Microsecond
+	RangeRequests   uint64        `json:"range_requests"`
+	RangeHits       uint64        `json:"range_hits"`
+	RangeMisses     uint64        `json:"range_misses"`
+	RangeAvg        time.Duration `json:"range_average_request"` // Microsecond
+	Range95         time.Duration `json:"range_95"`              // Microsecond
+	Range99         time.Duration `json:"range_99"`              // Microsecond
+	DBSize          int64         `json:"db_size"`
+	DBMtime         int64         `json:"db_mtime"`
 }
 
 func (s *httpServer) statsHandler(w http.ResponseWriter, req *http.Request) {
 	getStats := s.GetMetrics.Stats()
 	mgetStats := s.MgetMetrics.Stats()
+	fwMatchStats := s.FwMatchMetrics.Stats()
+	rangeStats := s.RangeMetrics.Stats()
 	size, mtime := s.ctx.db.Info()
 	stats := statsResponse{
-		Requests:     atomic.LoadUint64(&s.Requests),
-		SeekCount:    s.ctx.db.SeekCount(),
-		GetRequests:  atomic.LoadUint64(&s.GetRequests),
-		GetHits:      atomic.LoadUint64(&s.GetHits),
-		GetMisses:    atomic.LoadUint64(&s.GetMisses),
-		GetAvg:       getStats.Avg / time.Microsecond,
-		Get95:        getStats.P95 / time.Microsecond,
-		Get99:        getStats.P99 / time.Microsecond,
-		MgetRequests: atomic.LoadUint64(&s.MgetRequests),
-		MgetHits:     atomic.LoadUint64(&s.MgetHits),
-		MgetMisses:   atomic.LoadUint64(&s.MgetMisses),
-		MgetAvg:      mgetStats.Avg / time.Microsecond,
-		Mget95:       mgetStats.P95 / time.Microsecond,
-		Mget99:       mgetStats.P99 / time.Microsecond,
-		DBSize:       int64(size),
-		DBMtime:      mtime.Unix(),
+		Requests:        atomic.LoadUint64(&s.Requests),
+		SeekCount:       s.ctx.db.SeekCount(),
+		GetRequests:     atomic.LoadUint64(&s.GetRequests),
+		GetHits:         atomic.LoadUint64(&s.GetHits),
+		GetMisses:       atomic.LoadUint64(&s.GetMisses),
+		GetAvg:          getStats.Avg / time.Microsecond,
+		Get95:           getStats.P95 / time.Microsecond,
+		Get99:           getStats.P99 / time.Microsecond,
+		MgetRequests:    atomic.LoadUint64(&s.MgetRequests),
+		MgetHits:        atomic.LoadUint64(&s.MgetHits),
+		MgetMisses:      atomic.LoadUint64(&s.MgetMisses),
+		MgetAvg:         mgetStats.Avg / time.Microsecond,
+		Mget95:          mgetStats.P95 / time.Microsecond,
+		Mget99:          mgetStats.P99 / time.Microsecond,
+		FwMatchRequests: atomic.LoadUint64(&s.FwMatchRequests),
+		FwMatchHits:     atomic.LoadUint64(&s.FwMatchHits),
+		FwMatchMisses:   atomic.LoadUint64(&s.FwMatchMisses),
+		FwMatchAvg:      fwMatchStats.Avg / time.Microsecond,
+		FwMatch95:       fwMatchStats.P95 / time.Microsecond,
+		FwMatch99:       fwMatchStats.P99 / time.Microsecond,
+		RangeRequests:   atomic.LoadUint64(&s.RangeRequests),
+		RangeHits:       atomic.LoadUint64(&s.RangeHits),
+		RangeMisses:     atomic.LoadUint64(&s.RangeMisses),
+		RangeAvg:        rangeStats.Avg / time.Microsecond,
+		Range95:         rangeStats.P95 / time.Microsecond,
+		Range99:         rangeStats.P99 / time.Microsecond,
+		DBSize:          int64(size),
+		DBMtime:         mtime.Unix(),
 	}
 	// evbuffer_add_printf(evb, "\"total_seeks\": %"PRIu64",", total_seeks);
 

--- a/http.go
+++ b/http.go
@@ -171,7 +171,7 @@ func (s *httpServer) fwmatchHandler(w http.ResponseWriter, req *http.Request) {
 	atomic.AddUint64(&s.FwMatchRequests, 1)
 
 	needle := []byte(key)
-	content := s.ctx.db.RangeMatch(needle, nil)
+	content := s.ctx.db.ForwardMatch(needle)
 
 	if len(content) == 0 {
 		atomic.AddUint64(&s.FwMatchMisses, 1)

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -124,6 +124,12 @@ func (db *DB) beginningOfLine(i int) int {
 	return lastIndexByte(db.data, i, db.LineEnding) + 1
 }
 
+// endOfLine locates the end of the line that includes i
+// by searching for the first line separator occurrence after i.
+func (db *DB) endOfLine(i int) int {
+	return indexByte(db.data, i, db.size, db.LineEnding)
+}
+
 // lastIndexByte returns the index of the first instance of c in s before i. If
 // c is not present in s, or -1 if c is not present in s before i.
 func lastIndexByte(s []byte, i int, c byte) int {
@@ -169,7 +175,7 @@ func (db *DB) findFirstMatch(needle []byte, isMatch func([]byte, []byte) bool) i
 		}
 		endOfKey := indexByte(db.data, previous, db.size, db.RecordSeparator)
 		if endOfKey < 0 {
-			endOfKey = indexByte(db.data, previous, db.size, db.LineEnding)
+			endOfKey = db.endOfLine(previous)
 		}
 		if endOfKey < 0 {
 			endOfKey = db.size
@@ -213,7 +219,7 @@ func (db *DB) Search(needle []byte) []byte {
 	}
 	previous := db.beginningOfLine(i)
 
-	lineEnd := indexByte(db.data, previous, db.size, db.LineEnding)
+	lineEnd := db.endOfLine(previous)
 	// intentionally make a copy of data
 	line := []byte(db.data[previous:lineEnd])
 	db.RUnlock()

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -175,7 +175,6 @@ func (db *DB) findFirstMatch(needle []byte, isMatch func([]byte, []byte) bool) i
 		if endOfKey < 0 {
 			endOfKey = db.size
 		}
-
 		return isMatch(db.data[previous:endOfKey], needle)
 	})
 }
@@ -213,7 +212,6 @@ func (db *DB) Search(needle []byte) []byte {
 		db.RUnlock()
 		return nil
 	}
-
 	previous := db.beginningOfLine(i)
 
 	lineEnd := indexByte(db.data, previous, db.size, db.LineEnding)
@@ -236,19 +234,16 @@ func (db *DB) RangeMatch(startNeedle []byte, endNeedle []byte) []byte {
 	if db.size <= 0 {
 		panic("DB not Mapped")
 	}
-
 	if endNeedle != nil && bytes.Compare(startNeedle, endNeedle) > 0 {
 		// end is smaller than start, so the range is ill-defined
 		db.RUnlock()
 		return nil
 	}
-
 	startRecord := db.findStartOfRange(startNeedle)
 	if startRecord < 0 || startRecord == db.size {
 		db.RUnlock()
 		return nil
 	}
-
 	startIndex := db.beginningOfLine(startRecord)
 
 	endIndex := db.size
@@ -258,7 +253,6 @@ func (db *DB) RangeMatch(startNeedle []byte, endNeedle []byte) []byte {
 			endIndex = db.beginningOfLine(endRecord)
 		}
 	}
-
 	// intentionally make a copy of data
 	records := []byte(db.data[startIndex:endIndex])
 	db.RUnlock()

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -116,7 +116,9 @@ func (db *DB) Remap() error {
 	return nil
 }
 
-// LastIndexByte returns the index of the first instance of c in s, or -1 if c is not present in s after start.
+// lastIndexByte returns the index of the first instance of c in s before i. If
+// c is not present in s,or -1 if c is not present in s before i, then -1 is
+// returned.
 func lastIndexByte(s []byte, i int, c byte) int {
 	for ; i >= 0; i-- {
 		if s[i] == c {
@@ -126,7 +128,8 @@ func lastIndexByte(s []byte, i int, c byte) int {
 	return -1
 }
 
-// IndexByte returns the index of the first instance of c in s after i but before m. If c is not present in s -1 is returned
+// indexByte returns the index of the first instance of c in s after i but
+// before m. If c is not present in s between i and m, then -1 is returned.
 func indexByte(s []byte, i, m int, c byte) int {
 	for ; i < m; i++ {
 		if s[i] == c {
@@ -136,16 +139,17 @@ func indexByte(s []byte, i, m int, c byte) int {
 	return -1
 }
 
-// findFirstRecordAfterMatch performs a binary search to find the first record after
-// needle prefix matches. If includeExactMatch is set, returns the first record that exactly matches,
-// if it exists.
+// findFirstRecordAfterMatch performs a binary search to find the first record
+// after needle prefix matches. If includeExactMatch is set, returns the first
+// record that exactly matches, if it exists.
 func (db *DB) findFirstRecordAfterMatch(needle []byte, includeExactMatch bool) int {
 	needleLen := len(needle)
 
-	// binary search to find the index that matches our needle (starting at the previous line)
-	// note: this could be more efficient if we wrote our own search as we could skip data we've checked
-	// isntead of checking potentially more indexes here. Because page sizes is 4k this should hopefully
-	// matter less
+	// binary search to find the index that matches our needle,
+	// starting at the previous line.
+	// note: this could be more efficient if we wrote our own search as we could
+	// skip data we've checked instead of checking potentially more indexes here.
+	// Because page size is 4k this should hopefully matter less.
 	return sort.Search(db.size, func(i int) bool {
 		// find previous line starting point
 		atomic.AddUint64(&db.seekCount, 1)
@@ -171,7 +175,7 @@ func (db *DB) findFirstRecordAfterMatch(needle []byte, includeExactMatch bool) i
 }
 
 // Search uses a binary search looking for needle, and returns the full match line.
-// the needle should already have the record separator appended
+// needle should already end with the record separator.
 func (db *DB) Search(needle []byte) []byte {
 	db.RLock()
 
@@ -200,9 +204,10 @@ func (db *DB) Search(needle []byte) []byte {
 	return nil
 }
 
-// RangeMatch uses binary searches to look for startNeedle and (if not nil) endNeedle.
-// Returns all full match lines that fall between startNeedle and endNeedle, inclusive.
-// startNeedle and endNeedle should already have the record separator appended.
+// RangeMatch uses binary searches to look for startNeedle and (if not nil)
+// endNeedle. Returns all full match lines that fall between startNeedle and
+// endNeedle, inclusive. startNeedle and endNeedle should already both end
+// with the record separator.
 func (db *DB) RangeMatch(startNeedle []byte, endNeedle []byte) []byte {
 	db.RLock()
 

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -155,7 +155,7 @@ func indexByte(s []byte, i, m int, c byte) int {
 // findFirstMatch performs a binary search to find the first record
 // that matches needle using the given isMatch function, or -1 if
 // no match is found.
-func (db *DB) findFirstMatch(needle []byte, isMatch func([]byte, []byte) bool) int {
+func (db *DB) findFirstMatch(needle []byte, isMatch func([]byte) bool) int {
 	needleLen := len(needle)
 
 	// binary search to find the index that matches our needle,
@@ -180,7 +180,7 @@ func (db *DB) findFirstMatch(needle []byte, isMatch func([]byte, []byte) bool) i
 		if endOfKey < 0 {
 			endOfKey = db.size
 		}
-		return isMatch(db.data[previous:endOfKey], needle)
+		return isMatch(db.data[previous:endOfKey])
 	})
 }
 
@@ -189,8 +189,8 @@ func (db *DB) findFirstMatch(needle []byte, isMatch func([]byte, []byte) bool) i
 // In other words, it finds the first record in the range started by
 // startNeedle.
 func (db *DB) findStartOfRange(startNeedle []byte) int {
-	return db.findFirstMatch(startNeedle, func(a []byte, b []byte) bool {
-		return bytes.Compare(a, b) >= 0
+	return db.findFirstMatch(startNeedle, func(key []byte) bool {
+		return bytes.Compare(key, startNeedle) >= 0
 	})
 }
 
@@ -199,8 +199,8 @@ func (db *DB) findStartOfRange(startNeedle []byte) int {
 // In other words, it finds the first record beyond the range ended by
 // endNeedle.
 func (db *DB) findEndOfRange(endNeedle []byte) int {
-	return db.findFirstMatch(endNeedle, func(a []byte, b []byte) bool {
-		return bytes.Compare(a, b) > 0
+	return db.findFirstMatch(endNeedle, func(key []byte) bool {
+		return bytes.Compare(key, endNeedle) > 0
 	})
 }
 

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -288,7 +288,7 @@ func (db *DB) RangeMatch(startNeedle []byte, endNeedle []byte) []byte {
 	if db.size <= 0 {
 		panic("DB not Mapped")
 	}
-	if endNeedle != nil && bytes.Compare(startNeedle, endNeedle) > 0 {
+	if bytes.Compare(startNeedle, endNeedle) > 0 {
 		// end is smaller than start, so the range is ill-defined
 		db.RUnlock()
 		return nil
@@ -301,11 +301,9 @@ func (db *DB) RangeMatch(startNeedle []byte, endNeedle []byte) []byte {
 	startIndex := db.beginningOfLine(startRecord)
 
 	endIndex := db.size
-	if endNeedle != nil {
-		endRecord := db.findEndOfRange(endNeedle)
-		if endRecord >= 0 && endRecord < db.size {
-			endIndex = db.beginningOfLine(endRecord)
-		}
+	endRecord := db.findEndOfRange(endNeedle)
+	if endRecord >= 0 && endRecord < db.size {
+		endIndex = db.beginningOfLine(endRecord)
 	}
 	// intentionally make a copy of data
 	records := []byte(db.data[startIndex:endIndex])

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -206,7 +206,6 @@ func (db *DB) findEndOfRange(endNeedle []byte) int {
 }
 
 // Search uses a binary search looking for needle, and returns the full match line.
-// needle should already end with the record separator.
 func (db *DB) Search(needle []byte) []byte {
 	db.RLock()
 

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -116,12 +116,13 @@ func (db *DB) Remap() error {
 	return nil
 }
 
-// beginningOfLine retrieves the beginning of the line that includes i
-// by searching for the last line separator occurrence before position.
+// beginningOfLine locates the beginning of the line that includes i
+// by searching for the last line separator occurrence before i.
 func (db *DB) beginningOfLine(i int) int {
-	// sets the index to the first non-line-ending byte (or to the
+	previous := lastIndexByte(db.data, i, db.LineEnding)
+	// returns the index to the first non-line-ending byte (or to the
 	// beginning of the DB if no line ending is found)
-	return lastIndexByte(db.data, i, db.LineEnding) + 1
+	return previous + 1
 }
 
 // endOfLine locates the end of the line that includes i

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -125,8 +125,7 @@ func (db *DB) beginningOfLine(i int) int {
 }
 
 // lastIndexByte returns the index of the first instance of c in s before i. If
-// c is not present in s,or -1 if c is not present in s before i, then -1 is
-// returned.
+// c is not present in s, or -1 if c is not present in s before i.
 func lastIndexByte(s []byte, i int, c byte) int {
 	for ; i >= 0; i-- {
 		if s[i] == c {
@@ -189,8 +188,8 @@ func (db *DB) findStartOfRange(startNeedle []byte) int {
 	})
 }
 
-// findStartOfRange finds the first record that is lexically greater than
-// startNeedle.
+// findEndOfRange finds the first record that is lexically greater than
+// endNeedle.
 // In other words, it finds the first record beyond the range ended by
 // endNeedle.
 func (db *DB) findEndOfRange(endNeedle []byte) int {

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -53,7 +53,7 @@ func TestSearch(t *testing.T) {
 			result = result[len(tc.needle)+1:]
 		}
 		if !bytes.Equal(result, []byte(tc.expected)) {
-			t.Errorf("expected %q got %q expected %q", tc.needle, result, tc.expected)
+			t.Errorf("query %q got %q expected %q", tc.needle, result, tc.expected)
 		}
 	}
 

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -64,34 +64,36 @@ func TestSearch(t *testing.T) {
 // Tests that slices returned by Search aren't modified by changes
 // to the DB file afterwards.
 func TestSearchWhileWriting(t *testing.T) {
-	fi, err := os.Open("../test_data/testdb.tab")
+	f, err := os.Open("../test_data/testdb.tab")
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
 	// Create a temporary copy of the DB file since we have to write to the DB
 	// for this test to work
-	f, err := ioutil.TempFile("../test_data", "tmp_testdb")
+	fTmp, err := ioutil.TempFile("../test_data", "tmp_testdb")
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
-	defer os.Remove(f.Name())
-	io.Copy(f, fi)
+	defer os.Remove(fTmp.Name())
+	io.Copy(fTmp, f)
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
-	db, err := New(f)
+	db, err := New(fTmp)
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
 	tc := testSearch{"a", "first record"}
 	result := db.Search([]byte(tc.needle))
 
-	toWrite := len(tc.expected) + len(tc.needle) + 1
-	w, err := f.WriteAt(make([]byte, toWrite), 0)
+	// Overwrite the temporary file with a bunch of 0s,
+	// thus changing db.data (since it's mMapped to the file)
+	l := len(tc.expected) + len(tc.needle) + 1
+	n, err := f.WriteAt(make([]byte, l), 0)
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
-	if w != toWrite {
+	if n != l {
 		t.Fatalf("failed to overwrite record in DB file")
 	}
 	if len(result) > 0 {

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -89,7 +89,7 @@ func TestSearchWhileWriting(t *testing.T) {
 	// Overwrite the temporary file with a bunch of 0s,
 	// thus changing db.data (since it's mMapped to the file)
 	l := len(tc.expected) + len(tc.needle) + 1
-	n, err := f.WriteAt(make([]byte, l), 0)
+	n, err := fTmp.WriteAt(make([]byte, l), 0)
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -82,3 +82,92 @@ func TestSearchCharset(t *testing.T) {
 		}
 	}
 }
+
+func TestForwardMatch(t *testing.T) {
+	f, err := os.Open("../test_data/testdb.tab")
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+	db, err := New(f)
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+
+	for _, tc := range []testSearch{
+		{"prefix", `prefix.1	how
+prefix.2	are
+prefix.3	you
+q	r
+s	t
+u	v
+w	x
+y	z
+zzzzzzzzzzzzzzzzzzzzzzzz	almost-sleepy
+zzzzzzzzzzzzzzzzzzzzzzzzz	very-sleepy
+zzzzzzzzzzzzzzzzzzzzzzzzzz	already-asleep
+`},
+		{"y", `y	z
+zzzzzzzzzzzzzzzzzzzzzzzz	almost-sleepy
+zzzzzzzzzzzzzzzzzzzzzzzzz	very-sleepy
+zzzzzzzzzzzzzzzzzzzzzzzzzz	already-asleep
+`},
+
+		{"y1", `zzzzzzzzzzzzzzzzzzzzzzzz	almost-sleepy
+zzzzzzzzzzzzzzzzzzzzzzzzz	very-sleepy
+zzzzzzzzzzzzzzzzzzzzzzzzzz	already-asleep
+`},
+
+		{"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", ""},
+	} {
+		actualRecords := db.RangeMatch([]byte(tc.needle), nil)
+		expectedRecords := []byte(tc.expected)
+
+		if bytes.Compare(expectedRecords, actualRecords) != 0 {
+			t.Errorf("for forward match from %q:\nExpected %q but got %q", tc.needle, expectedRecords, actualRecords)
+		}
+	}
+}
+
+type testRangeSearch struct {
+	startNeedle string
+	endNeedle   string
+	expected    string
+}
+
+func TestRangeMatch(t *testing.T) {
+	f, err := os.Open("../test_data/testdb.tab")
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+	db, err := New(f)
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+
+	for _, tc := range []testRangeSearch{
+		{"b", "c1", `b	third
+c	d
+`},
+		{"0", "9", ""},
+		{"p", "prefix.3", `prefix.1	how
+prefix.2	are
+prefix.3	you
+`},
+		{"prefix.11", "prefix.3", `prefix.2	are
+prefix.3	you
+`},
+		{"y", "z", "y	z\n"},
+
+		{"y1", "zzzzzzzzzzzzzzzzzzzzzzzz", `zzzzzzzzzzzzzzzzzzzzzzzz	almost-sleepy
+`},
+
+		{"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", ""},
+	} {
+		actualRecords := db.RangeMatch([]byte(tc.startNeedle), []byte(tc.endNeedle))
+		expectedRecords := []byte(tc.expected)
+
+		if bytes.Compare(expectedRecords, actualRecords) != 0 {
+			t.Errorf("for forward match from %q to %q:\nExpected %q but got %q", tc.startNeedle, tc.endNeedle, expectedRecords, actualRecords)
+		}
+	}
+}

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -94,32 +94,21 @@ func TestForwardMatch(t *testing.T) {
 	}
 
 	for _, tc := range []testSearch{
-		{"prefix", `prefix.1	how
+		{"pre", `prefix.1	how
 prefix.2	are
 prefix.3	you
-q	r
-s	t
-u	v
-w	x
-y	z
-zzzzzzzzzzzzzzzzzzzzzzzz	almost-sleepy
-zzzzzzzzzzzzzzzzzzzzzzzzz	very-sleepy
-zzzzzzzzzzzzzzzzzzzzzzzzzz	already-asleep
 `},
 		{"y", `y	z
-zzzzzzzzzzzzzzzzzzzzzzzz	almost-sleepy
-zzzzzzzzzzzzzzzzzzzzzzzzz	very-sleepy
-zzzzzzzzzzzzzzzzzzzzzzzzzz	already-asleep
 `},
 
-		{"y1", `zzzzzzzzzzzzzzzzzzzzzzzz	almost-sleepy
+		{"zzzzzz", `zzzzzzzzzzzzzzzzzzzzzzzz	almost-sleepy
 zzzzzzzzzzzzzzzzzzzzzzzzz	very-sleepy
 zzzzzzzzzzzzzzzzzzzzzzzzzz	already-asleep
 `},
 
 		{"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", ""},
 	} {
-		actualRecords := db.RangeMatch([]byte(tc.needle), nil)
+		actualRecords := db.ForwardMatch([]byte(tc.needle))
 		expectedRecords := []byte(tc.expected)
 
 		if bytes.Compare(expectedRecords, actualRecords) != 0 {

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -2,6 +2,8 @@ package sorted_db
 
 import (
 	"bytes"
+	"io"
+	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -57,6 +59,47 @@ func TestSearch(t *testing.T) {
 		}
 	}
 
+}
+
+// Tests that slices returned by Search aren't modified by changes
+// to the DB file afterwards.
+func TestSearchWhileWriting(t *testing.T) {
+	fi, err := os.Open("../test_data/testdb.tab")
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+	// Create a temporary copy of the DB file since we have to write to the DB
+	// for this test to work
+	f, err := ioutil.TempFile("../test_data", "tmp_testdb")
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+	defer os.Remove(f.Name())
+	io.Copy(f, fi)
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+	db, err := New(f)
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+	tc := testSearch{"a", "first record"}
+	result := db.Search([]byte(tc.needle))
+
+	toWrite := len(tc.expected) + len(tc.needle) + 1
+	w, err := f.WriteAt(make([]byte, toWrite), 0)
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+	if w != toWrite {
+		t.Fatalf("failed to overwrite record in DB file")
+	}
+	if len(result) > 0 {
+		result = result[len(tc.needle)+1:]
+	}
+	if !bytes.Equal(result, []byte(tc.expected)) {
+		t.Errorf("query %q got %q expected %q", tc.needle, result, tc.expected)
+	}
 }
 
 func TestSearchCharset(t *testing.T) {

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -149,6 +149,7 @@ func TestRangeMatch(t *testing.T) {
 c	d
 `},
 		{"0", "9", ""},
+		{"c", "b", ""},
 		{"p", "prefix.3", `prefix.1	how
 prefix.2	are
 prefix.3	you

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -145,10 +145,15 @@ func TestRangeMatch(t *testing.T) {
 	}
 
 	for _, tc := range []testRangeSearch{
+		{"0", "9", ""},
+		{"0", "c1", `a	first record
+aa	another first
+b	third
+c	d
+`},
 		{"b", "c1", `b	third
 c	d
 `},
-		{"0", "9", ""},
 		{"c", "b", ""},
 		{"p", "prefix.3", `prefix.1	how
 prefix.2	are
@@ -156,6 +161,11 @@ prefix.3	you
 `},
 		{"prefix.11", "prefix.3", `prefix.2	are
 prefix.3	you
+`},
+		{"y", "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", `y	z
+zzzzzzzzzzzzzzzzzzzzzzzz	almost-sleepy
+zzzzzzzzzzzzzzzzzzzzzzzzz	very-sleepy
+zzzzzzzzzzzzzzzzzzzzzzzzzz	already-asleep
 `},
 		{"y", "z", "y	z\n"},
 


### PR DESCRIPTION
Added two new endpoints to sortdb. The first, `fwmatch`, behaves in the same way as the version in bitly/simplehttp (finding the range of prefix-matching keys). The second, `range`, is a new feature that finds all records with keys inside the range specified by `start` and `end` parameters. See issue #2 for more details on `range`.

These changes required some refactoring of db.go, and the lifting of a restriction that forced http.go to append record separators to search queries before sending them to DB.

This PR has merged in the fix for #4, and therefore depends on PR #5.
