### PR TITLE
mlock support

### DIFF
--- a/sortdb.go
+++ b/sortdb.go
@@ -20,6 +20,7 @@ func main() {
 	httpAddress := flag.String("http-address", ":8080", "http address to listen on")
 	fieldSeparator := flag.String("field-separator", "\t", "field separator (eg: comma, tab, pipe)")
 	requestLogging := flag.Bool("enable-logging", false, "request logging")
+	mlock := flag.Bool("mlock", false, "lock pages in memory")
 
 	flag.Parse()
 
@@ -36,7 +37,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("ERROR opening %q %s", *file, err)
 	}
-	db, err := sorted_db.New(f)
+	db, err := sorted_db.New(f, *mlock)
 	if err != nil {
 		log.Fatalf("ERROR creating db %s", err)
 	}

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -65,6 +65,16 @@ func (db *DB) Open(f *os.File) error {
 	db.f = f
 	db.data = data
 	db.size = size
+	lockerr := data.Lock()
+	if lockerr == nil {
+		log.Printf("DB MLock engaged!")
+	} else {
+		// Fixme -- print error for real
+		// Also for our purposes it would probably be better
+		// to flat-out quit in this case. Also, a command-line option,
+		// bla bla...
+		log.Printf("DB MLock could not be engaged: %s", err)
+	}
 	return nil
 }
 

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -71,7 +71,6 @@ func (db *DB) Open(f *os.File) error {
 		if lockErr == nil {
 			log.Printf("DB MLock engaged!")
 		} else {
-			// Quit immediately in this case.
 			log.Fatalf("ERROR: DB MLock could not be engaged: %s", lockErr)
 		}
 	}

--- a/sorted_db/db.go
+++ b/sorted_db/db.go
@@ -71,9 +71,8 @@ func (db *DB) Open(f *os.File) error {
 		if lockErr == nil {
 			log.Printf("DB MLock engaged!")
 		} else {
-			// Fixme -- print error for real
-			// make sure quits
-			log.Printf("DB MLock could not be engaged: %s", err)
+			// Quit immediately in this case.
+			log.Fatalf("ERROR: DB MLock could not be engaged: %s", lockErr)
 		}
 	}
 	return nil

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -33,7 +33,7 @@ type testSearch struct {
 	expected string
 }
 
-func _TestSearch(t *testing.T, mlock bool) {
+func testSearchHelper(t *testing.T, mlock bool) {
 	f, err := os.Open("../test_data/testdb.tab")
 	if err != nil {
 		t.Fatalf("got error %s", err)
@@ -61,12 +61,12 @@ func _TestSearch(t *testing.T, mlock bool) {
 
 }
 
-func TestSearch(t *testing.T) {
-	_TestSearch(t, false)
+func TestSearchWithoutMlock(t *testing.T) {
+	testSearchHelper(t, false)
 }
 
-func TestSearchMlock(t *testing.T) {
-	_TestSearch(t, true)
+func TestSearchWithMlock(t *testing.T) {
+	testSearchHelper(t, true)
 }
 
 // Tests that slices returned by Search aren't modified by changes

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -33,12 +33,12 @@ type testSearch struct {
 	expected string
 }
 
-func TestSearch(t *testing.T) {
+func _TestSearch(t *testing.T, mlock bool) {
 	f, err := os.Open("../test_data/testdb.tab")
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
-	db, err := New(f, false)
+	db, err := New(f, mlock)
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
@@ -59,6 +59,14 @@ func TestSearch(t *testing.T) {
 		}
 	}
 
+}
+
+func TestSearch(t *testing.T) {
+	_TestSearch(t, false)
+}
+
+func TestSearchMlock(t *testing.T) {
+	_TestSearch(t, true)
 }
 
 // Tests that slices returned by Search aren't modified by changes

--- a/sorted_db/db_test.go
+++ b/sorted_db/db_test.go
@@ -38,7 +38,7 @@ func TestSearch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
-	db, err := New(f)
+	db, err := New(f, false)
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
@@ -79,7 +79,7 @@ func TestSearchWhileWriting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
-	db, err := New(fTmp)
+	db, err := New(fTmp, false)
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
@@ -109,7 +109,7 @@ func TestSearchCharset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
-	db, err := New(f)
+	db, err := New(f, false)
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
@@ -133,7 +133,7 @@ func TestForwardMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
-	db, err := New(f)
+	db, err := New(f, false)
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
@@ -173,7 +173,7 @@ func TestRangeMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}
-	db, err := New(f)
+	db, err := New(f, false)
 	if err != nil {
 		t.Fatalf("got error %s", err)
 	}


### PR DESCRIPTION
The C version of sortdb supported a call to mlock to lock the DB file in memory:
https://github.com/bitly/simplehttp/blob/master/sortdb/sortdb.c#L363

This adds this option back in. I'm not sure how much use it will be to others, but it's been useful in ensuring our large DB file is completely loaded in memory before serving and while serving, making sure requests are fast from the start and stay fast.

Note that when using with Docker (at least with large files), the option `--cap-add IPC_LOCK` must be used (Marathon config: `parameters: [ { "key": "cap-add", "value": "IPC_LOCK" } ]`).

The following branch has this and my previous bugfix:
https://github.com/jehiah/sortdb/compare/master...seomoz:evan/mlock

CC @noam-c @tony-bye @erinren
